### PR TITLE
Making it easier to clone project

### DIFF
--- a/content/tutorial/rest/openapi/petstore/environment.md
+++ b/content/tutorial/rest/openapi/petstore/environment.md
@@ -23,11 +23,11 @@ networknt under your home directory.
 cd ~
 mkdir networknt
 cd networknt
-git clone git@github.com:networknt/light-codegen.git
-git clone git@github.com:networknt/light-example-4j.git
-git clone git@github.com:networknt/light-oauth2.git
-git clone git@github.com:networknt/light-docker.git
-git clone git@github.com:networknt/model-config.git
+git clone https://github.com/networknt/light-codegen.git
+git clone https://github.com/networknt/light-example-4j.git
+git clone https://github.com/networknt/light-oauth2.git
+git clone https://github.com/networknt/light-docker.git
+git clone https://github.com/networknt/model-config.git
 ```
 
 We are going to re-generate petstore project in light-example-4j. So let's rename


### PR DESCRIPTION
I got this error when I tried to clone project:

```
Cloning into 'light-docker'...
Warning: Permanently added the RSA host key for IP address '<IPADDRESS>' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Perhaps this change would make it easier to follow the documentation. 
  