### PR TITLE
Fix the rest swagger db page order prev/next links

### DIFF
--- a/content/tutorial/rest/swagger/database/connection-pool.md
+++ b/content/tutorial/rest/swagger/database/connection-pool.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 70      #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/dbscripts.md
+++ b/content/tutorial/rest/swagger/database/dbscripts.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 50      #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/generation.md
+++ b/content/tutorial/rest/swagger/database/generation.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 30      #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/multiple-queries.md
+++ b/content/tutorial/rest/swagger/database/multiple-queries.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 80      #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/multiple-updates.md
+++ b/content/tutorial/rest/swagger/database/multiple-updates.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 90      #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/performance.md
+++ b/content/tutorial/rest/swagger/database/performance.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 110     #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/preparation.md
+++ b/content/tutorial/rest/swagger/database/preparation.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 10	#rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/single-query.md
+++ b/content/tutorial/rest/swagger/database/single-query.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 70      #rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/specification.md
+++ b/content/tutorial/rest/swagger/database/specification.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 20	#rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/startdb.md
+++ b/content/tutorial/rest/swagger/database/startdb.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 60	#rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/test.md
+++ b/content/tutorial/rest/swagger/database/test.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 40	#rem
 aliases: []
 toc: false
 draft: false

--- a/content/tutorial/rest/swagger/database/unit-test.md
+++ b/content/tutorial/rest/swagger/database/unit-test.md
@@ -5,6 +5,7 @@ description: ""
 categories: []
 keywords: []
 slug: ""
+weight: 100     #rem
 aliases: []
 toc: false
 draft: false


### PR DESCRIPTION
This seems to fix the rest swagger database pages with no ill affect on the TOC.